### PR TITLE
Disable auto correction.

### DIFF
--- a/CYRTextView/CYRTextView.m
+++ b/CYRTextView/CYRTextView.m
@@ -97,6 +97,7 @@ static const float kCursorVelocity = 1.0f/8.0f;
     // Setup defaults
     self.font = [UIFont systemFontOfSize:16.0f];
     self.autocapitalizationType = UITextAutocapitalizationTypeNone;
+    self.autocorrectionType     = UITextAutocorrectionTypeNo;
     self.lineCursorEnabled = YES;
     
     // Inset the content to make room for line numbers


### PR DESCRIPTION
Since this is a textview implementation for aimed at code, we shouldn't be auto correcting the users input.
